### PR TITLE
Embeddings Manager script for managing local and remote embeddings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 csv_files/*
 embeddings/*
+.embeddings/*

--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,3 @@ cython_debug/
 
 csv_files/*
 embeddings/*
-.embeddings/*

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ poetry run python bin/chat.py --query "What is TP53 involved in?"
 ```
 This will execute the ChatBot with the provided query and print the response.
 
-### Generating Embeddings
+### Getting Embeddings
+
+Please refer to the [Embeddings Manager documentation](docs/embeddings_manager.md) for updated steps for either downloading or generating embeddings.
 
 #### Dependencies
 
@@ -71,7 +73,7 @@ Reactome Dockerized Graph database from DockerHub: [reactome/graphdb](https://hu
 To generate embeddings using the embedding generator script, use the following command:
 
 ```bash
-poetry run python bin/embedding_generator.py --openai-key=<your-key>
+python bin/embeddings_manager.py make openai/text-embedding-ada-002/reactome/Release89 --openai-key=<your-key>
 ```
 This command will generate embeddings using the specified OpenAI API key.
 
@@ -120,7 +122,7 @@ To make sure imports are organized
 
 
 ```bash
-poetry run iosort . 
+poetry run iosort .
 ```
 
 ## Contributing

--- a/bin/chat.py
+++ b/bin/chat.py
@@ -26,6 +26,10 @@ async def main() -> None:
         help="HuggingFace sentence_transformers model (alternative to OpenAI)",
     )
     parser.add_argument(
+        "--hf-key",
+        help="API key for HuggingFaceHub",
+    )
+    parser.add_argument(
         "--device",
         default="cpu",
         help="PyTorch device to use when running HuggingFace embeddings locally [cpu/cuda]",
@@ -34,6 +38,9 @@ async def main() -> None:
 
     if args.openai_key:
         os.environ["OPENAI_API_KEY"] = args.openai_key
+
+    if args.hf_key:
+        os.environ["HUGGINGFACEHUB_API_TOKEN"] = args.hf_key
 
     embeddings_directory = "embeddings"
     qa = initialize_retrieval_chain(

--- a/bin/chat.py
+++ b/bin/chat.py
@@ -6,6 +6,7 @@ import pyfiglet
 from dotenv import load_dotenv
 
 from src.reactome.retreival_chain import initialize_retrieval_chain
+from src.util.embedding_environment import EM_ARCHIVE, EmbeddingEnvironment
 
 
 async def main() -> None:
@@ -42,7 +43,7 @@ async def main() -> None:
     if args.hf_key:
         os.environ["HUGGINGFACEHUB_API_TOKEN"] = args.hf_key
 
-    embeddings_directory = "embeddings/reactome"
+    embeddings_directory = EM_ARCHIVE / EmbeddingEnvironment.get_dict()["reactome"]
     qa = initialize_retrieval_chain(
         embeddings_directory,
         True,

--- a/bin/chat.py
+++ b/bin/chat.py
@@ -42,7 +42,7 @@ async def main() -> None:
     if args.hf_key:
         os.environ["HUGGINGFACEHUB_API_TOKEN"] = args.hf_key
 
-    embeddings_directory = "embeddings"
+    embeddings_directory = "embeddings/reactome"
     qa = initialize_retrieval_chain(
         embeddings_directory,
         True,

--- a/bin/embeddings/alliance_generator.py
+++ b/bin/embeddings/alliance_generator.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 import sys
 from typing import Dict
@@ -16,7 +15,11 @@ from src.reactome.neo4j_connector import Neo4jConnector
 
 
 def upload_to_chromadb(
-    file: str, embedding_table: str, hf_model: str = None, device: str = "cpu"
+    embeddings_dir: str,
+    file: str,
+    embedding_table: str,
+    hf_model: str = None,
+    device: str = None,
 ) -> None:
     metadata_columns: Dict[str, list] = {
         "genes": [
@@ -40,17 +43,18 @@ def upload_to_chromadb(
     )
     docs = loader.load()
 
-    if device == "cuda":
-        torch.cuda.empty_cache()
-
     if hf_model is None:  # Use OpenAI
         embeddings = OpenAIEmbeddings()
+    elif hf_model.startswith("openai/text-embedding-"):
+        embeddings = OpenAIEmbeddings(model=hf_model[len("openai/"):])
     elif "HUGGINGFACEHUB_API_TOKEN" in os.environ:
         embeddings = HuggingFaceEndpointEmbeddings(
             huggingfacehub_api_token=os.environ["HUGGINGFACEHUB_API_TOKEN"],
             model=hf_model,
         )
     else:
+        if device == "cuda":
+            torch.cuda.empty_cache()
         embeddings = HuggingFaceEmbeddings(
             model_name=hf_model,
             model_kwargs={"device": device, "trust_remote_code": True},
@@ -60,74 +64,35 @@ def upload_to_chromadb(
     db = Chroma.from_documents(
         documents=docs,
         embedding=embeddings,
-        persist_directory="embeddings/" + embedding_table,
+        persist_directory=os.path.join(embeddings_dir, embedding_table),
     )
 
     return db
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Generate and load CSV files from Reactome Neo4j for the LangChain application"
-    )
-    parser.add_argument("--openai-key", help="API key for OpenAI")
-    parser.add_argument(
-        "--neo4j-uri",
-        default="bolt://localhost:7687",
-        help="URI for Neo4j database connection",
-    )
-    parser.add_argument(
-        "--neo4j-username",
-        required=False,
-        help="Username for Neo4j database connection",
-    )
-    parser.add_argument(
-        "--neo4j-password",
-        required=False,
-        help="Password for Neo4j database connection",
-    )
-    parser.add_argument(
-        "--force", action="store_true", help="Force regeneration of CSV files"
-    )
-    parser.add_argument(
-        "--hf-model",
-        help="HuggingFace sentence_transformers model (alternative to OpenAI)",
-    )
-    parser.add_argument(
-        "--hf-key",
-        help="API key for HuggingFaceHub",
-    )
-    parser.add_argument(
-        "--device",
-        default="cpu",
-        help="PyTorch device to use when running HuggingFace model locally [cpu/cuda]",
-    )
-    args = parser.parse_args()
-
-    if args.openai_key:
-        os.environ["OPENAI_API_KEY"] = args.openai_key
-
-    if args.hf_key:
-        os.environ["HUGGINGFACEHUB_API_TOKEN"] = args.hf_key
-
+def main(
+    embeddings_dir: str,
+    neo4j_uri: str = "bolt://localhost:7687",
+    neo4j_username: str = None,
+    neo4j_password: str = None,
+    force: bool = False,
+    hf_model: str = None,
+    device: str = None,
+) -> None:
     connector = Neo4jConnector(
-        uri=args.neo4j_uri, user=args.neo4j_password, password=args.neo4j_username
+        uri=neo4j_uri, user=neo4j_username, password=neo4j_password
     )
 
     (reactions_csv, summations_csv, complexes_csv, ewas_csv) = generate_all_csvs(
-        connector, args.force
+        connector, force
     )
     connector.close()
 
-    db = upload_to_chromadb(reactions_csv, "reactions", args.hf_model, args.device)
+    db = upload_to_chromadb(embeddings_dir, reactions_csv, "reactions", hf_model, device)
     print(db._collection.count())
-    db = upload_to_chromadb(summations_csv, "summations", args.hf_model, args.device)
+    db = upload_to_chromadb(embeddings_dir, summations_csv, "summations", hf_model, device)
     print(db._collection.count())
-    db = upload_to_chromadb(complexes_csv, "complexes", args.hf_model, args.device)
+    db = upload_to_chromadb(embeddings_dir, complexes_csv, "complexes", hf_model, device)
     print(db._collection.count())
-    db = upload_to_chromadb(ewas_csv, "ewas", args.hf_model, args.device)
+    db = upload_to_chromadb(embeddings_dir, ewas_csv, "ewas", hf_model, device)
     print(db._collection.count())
-
-
-if __name__ == "__main__":
-    main()

--- a/bin/embeddings/reactome_generator.py
+++ b/bin/embeddings/reactome_generator.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 import torch
 from langchain_community.vectorstores import Chroma
-from langchain_huggingface import HuggingFaceEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings, HuggingFaceEndpointEmbeddings
 from langchain_openai import OpenAIEmbeddings
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
@@ -54,6 +54,11 @@ def upload_to_chromadb(
 
     if hf_model is None:  # Use OpenAI
         embeddings = OpenAIEmbeddings()
+    elif "HUGGINGFACEHUB_API_TOKEN" in os.environ:
+        embeddings = HuggingFaceEndpointEmbeddings(
+            huggingfacehub_api_token=os.environ["HUGGINGFACEHUB_API_TOKEN"],
+            model=hf_model,
+        )
     else:
         embeddings = HuggingFaceEmbeddings(
             model_name=hf_model,
@@ -98,14 +103,21 @@ def main() -> None:
         help="HuggingFace sentence_transformers model (alternative to OpenAI)",
     )
     parser.add_argument(
+        "--hf-key",
+        help="API key for HuggingFaceHub",
+    )
+    parser.add_argument(
         "--device",
         default="cpu",
         help="PyTorch device to use when running HuggingFace model locally [cpu/cuda]",
     )
     args = parser.parse_args()
 
-    if args.openai_key is not None:
+    if args.openai_key:
         os.environ["OPENAI_API_KEY"] = args.openai_key
+
+    if args.hf_key:
+        os.environ["HUGGINGFACEHUB_API_TOKEN"] = args.hf_key
 
     connector = Neo4jConnector(
         uri=args.neo4j_uri, user=args.neo4j_password, password=args.neo4j_username

--- a/bin/embeddings_manager.py
+++ b/bin/embeddings_manager.py
@@ -1,0 +1,214 @@
+from argparse import ArgumentParser
+import os
+from pathlib import Path
+import re
+from typing import NamedTuple
+from zipfile import ZipFile, ZIP_DEFLATED
+
+import localstack_client.session as boto3
+
+
+REPO_ROOT = Path(__file__).parent.parent
+S3_BUCKET = "embeddings"
+
+
+class EmbeddingSelection(NamedTuple):
+    model: str
+    db: str
+    version: str
+
+    def __str__(self) -> str:
+        return "/".join(self)
+
+    def is_openai(self) -> bool:
+        return self.model.startswith("openai/text-embedding-")
+
+    def path(self, check_exists:bool=True) -> Path:
+        path = REPO_ROOT / ".embeddings" / str(self)
+        if check_exists and not path.is_dir():
+            exit(f"Embedding does not exist at {path}")
+        return path
+
+    @classmethod
+    def parse(cls, embedding_id:str): # -> Self
+        embedding_id = embedding_id.replace("\\", "/")
+        match = re.fullmatch(r"([^/]+/[^/]+)/([^/]+)/([^/]+)", embedding_id)
+        if match is None:
+            raise ValueError(f"malformed selection string '{embedding_id}'")
+        return cls(*match.groups())
+
+
+def pull(embedding: EmbeddingSelection):
+    embedding_path:Path = embedding.path(check_exists=False)
+    zip_tmpfile:Path = REPO_ROOT / ".embeddings/tmp.zip"
+    try:
+        s3 = boto3.client("s3")
+        print("Downloading...")
+        s3.download_file(S3_BUCKET, str(embedding), zip_tmpfile)
+        print("Decompressing...")
+        with ZipFile(zip_tmpfile, "r") as zipf:
+            zipf.extractall(embedding_path)
+    finally:
+        zip_tmpfile.unlink(missing_ok=True)
+    print(f"Saved to {embedding_path}")
+
+
+def use(embedding: EmbeddingSelection):
+    (REPO_ROOT / "embeddings").mkdir(exist_ok=True)
+    embedding_path:Path = embedding.path()
+    (REPO_ROOT / "embeddings" / embedding.db).unlink(missing_ok=True)
+    (REPO_ROOT / "embeddings" / embedding.db).symlink_to(embedding_path)
+    which()
+
+
+def install(embedding: EmbeddingSelection):
+    pull(embedding)
+    use(embedding)
+
+
+def make(
+    embedding: EmbeddingSelection,
+    openai_key: str = None,
+    hf_key: str = None,
+    **kwargs
+):
+    embedding_path:Path = embedding.path(check_exists=False)
+    if openai_key:
+        os.environ["OPENAI_API_KEY"] = openai_key
+    if hf_key:
+        os.environ["HUGGINGFACEHUB_API_TOKEN"] = hf_key
+    if embedding.db == "reactome":
+        from embeddings.reactome_generator import main
+        main(str(embedding_path), hf_model=embedding.model, **kwargs)
+    else:
+        raise NotImplementedError(f"db: {embedding.db}")
+    use(embedding)
+
+
+def push(embedding: EmbeddingSelection):
+    embedding_path:Path = embedding.path()
+    zip_tmpfile:Path = REPO_ROOT / ".embeddings/tmp.zip"
+    try:
+        print("Compressing...")
+        with ZipFile(zip_tmpfile, "w", ZIP_DEFLATED) as zipf:
+            for root, _, filenames in os.walk(embedding_path):
+                for filename in filenames:
+                    file_path = Path(root) / filename
+                    arc_name = file_path.relative_to(embedding_path)
+                    zipf.write(file_path, arc_name)
+        s3 = boto3.client("s3")
+        print("Uploading...")
+        s3.upload_file(zip_tmpfile, S3_BUCKET, str(embedding))
+    finally:
+        zip_tmpfile.unlink()
+    print("Pushed to S3.")
+
+
+def which():
+    for subdir in (REPO_ROOT / "embeddings").iterdir():
+        abs_path = subdir.resolve()
+        try:
+            display_path = abs_path.relative_to(REPO_ROOT / ".embeddings")
+        except ValueError:
+            display_path = abs_path
+        print(f"{subdir.name}:\t{display_path}")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+
+    # Parent parser for selecting embeddings
+    selection_parser = ArgumentParser(add_help=False)
+    selection_parser.add_argument(
+        "embedding",
+        type=EmbeddingSelection.parse,
+        help="Embedding selection: <modelorg>/<model>/<database>/<version>"
+    )
+
+    # Subcommands
+    subparsers = parser.add_subparsers(required=True)
+    pull_parser = subparsers.add_parser(
+        "pull",
+        parents=[selection_parser],
+        help="Download embeddings",
+    )
+    pull_parser.set_defaults(func=pull)
+    use_parser = subparsers.add_parser(
+        "use",
+        parents=[selection_parser],
+        help="Set the active embeddings",
+    )
+    use_parser.set_defaults(func=use)
+    install_parser = subparsers.add_parser(
+        "install",
+        parents=[selection_parser],
+        help="Download and set the active embeddings (pull+use)",
+    )
+    install_parser.set_defaults(func=install)
+    make_parser = subparsers.add_parser(
+        "make",
+        parents=[selection_parser],
+        help="Generate embeddings",
+    )
+    make_parser.set_defaults(func=make)
+    push_parser = subparsers.add_parser(
+        "push",
+        parents=[selection_parser],
+        help="Upload embeddings",
+    )
+    push_parser.set_defaults(func=push)
+    rm_parser = subparsers.add_parser(
+        "rm",
+        parents=[selection_parser],
+        help="Remove specified embedding (locally)",
+    )
+    ls_parser = subparsers.add_parser(
+        "ls",
+        help="List locally installed embeddings",
+    )
+    ls_remote_parser = subparsers.add_parser(
+        "ls-remote",
+        help="List available embeddings on S3",
+    )
+    which_parser = subparsers.add_parser(
+        "which",
+        help="Reveal the current embeddings in use",
+    )
+    which_parser.set_defaults(func=which)
+
+    # Command-specific arguments
+    make_parser.add_argument(
+        "--openai-key",
+        help="API key for OpenAI"
+    )
+    make_parser.add_argument(
+        "--hf-key",
+        help="API key for HuggingFaceHub",
+    )
+    make_parser.add_argument(
+        "--device",
+        help="PyTorch device to use when running HuggingFace model locally [cpu/cuda]",
+    )
+    make_parser.add_argument(
+        "--neo4j-uri",
+        default="bolt://localhost:7687",
+        help="URI for Neo4j database connection",
+    )
+    make_parser.add_argument(
+        "--neo4j-username",
+        help="Username for Neo4j database connection",
+    )
+    make_parser.add_argument(
+        "--neo4j-password",
+        help="Password for Neo4j database connection",
+    )
+    make_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force regeneration of CSV files"
+    )
+
+    args = parser.parse_args()
+    func = args.func
+    delattr(args, "func")
+    func(**vars(args))

--- a/bin/embeddings_manager.py
+++ b/bin/embeddings_manager.py
@@ -122,7 +122,9 @@ def ls_remote():
     s3 = boto3.resource("s3")
     s3_bucket = s3.Bucket(S3_BUCKET)
     for obj in s3_bucket.objects.filter(Prefix=str(S3_PREFIX)):
-        print(PurePosixPath(obj.key).relative_to(S3_PREFIX))
+        relative_path = PurePosixPath(obj.key).relative_to(S3_PREFIX)
+        if len(relative_path.parts) == 4:
+            print(relative_path)
 
 
 def which():

--- a/docs/embeddings_manager.md
+++ b/docs/embeddings_manager.md
@@ -1,0 +1,104 @@
+# Reactome Chatbot Embeddings Manager Script
+
+The script located at `bin/embeddings_manager.py` handles the generation, version-switching, and S3 upload/download of embeddings for the chatbot. Embeddings are installed locally to the `embeddings/` directory.
+
+```
+$ python .\bin\embeddings_manager.py -h
+usage: embeddings_manager.py [-h] {pull,use,install,make,push,rm,ls,ls-remote,which} ...
+
+positional arguments:
+  {pull,use,install,make,push,rm,ls,ls-remote,which}
+    pull                Download embeddings
+    use                 Set the active embeddings
+    install             Download and set the active embeddings (pull+use)
+    make                Generate embeddings
+    push                Upload embeddings
+    rm                  Remove specified embedding (locally)
+    ls                  List locally installed embeddings
+    ls-remote           List available embeddings on S3
+    which               Reveal the current embeddings in use
+
+optional arguments:
+  -h, --help            show this help message and exit
+```
+
+## Embedding Identifiers:
+
+The script specifies embeddings using strings with the following format:
+```
+<modelorg>/<model>/<database>/<version>
+```
+
+For example, the embeddings for Reactome Release89 using the default [OpenAI embeddings](https://platform.openai.com/docs/guides/embeddings/embedding-models) model (`text-embedding-ada-002`) are specified as:
+```
+openai/text-embedding-ada-002/reactome/Release89
+```
+
+For HuggingFace models, `<modelorg>/<model>` simply matches the HuggingFace model identifier.
+
+## Downloading Embeddings from S3
+
+Requires S3 read access.
+
+### List embeddings available to download: `ls-remote`
+```sh
+python bin/embeddings_manager.py ls-remote
+```
+
+### Download embedding: `pull`
+```sh
+python bin/embeddings_manager.py pull openai/text-embedding-ada-002/reactome/Release89
+```
+
+## Managing Local Embeddings:
+
+### List installed embeddings: `ls`
+```sh
+python bin/embeddings_manager.py ls
+```
+
+### Select an embedding for use: `use`
+```sh
+python bin/embeddings_manager.py use openai/text-embedding-ada-002/reactome/Release89
+```
+
+### Check the current embeddings in use: `which`
+```
+$ python bin/embeddings_manager.py which
+reactome:       nomic-ai\nomic-embed-text-v1.5\reactome\Release89
+alliance:       ...
+...
+```
+
+## Generate Embeddings: `make`
+
+### Reactome:
+
+#### Requirements:
+
+- Reactome Dockerized Graph database from DockerHub: [reactome/graphdb](https://hub.docker.com/r/reactome/graphdb)
+    + Be sure to note the Release# in use.
+
+#### OpenAi generation (remote):
+```sh
+python bin/embeddings_manager.py make openai/text-embedding-ada-002/reactome/<Release#> --openai-key <your-key>
+```
+
+#### HuggingFace generation (local):
+```sh
+python bin/embeddings_manager.py make <hf-model>/reactome/<Release#> --device <cpu/cuda>
+```
+
+#### HuggingFaceHub generation (remote):
+Either specify `--hf-key` or environment variable `HUGGINGFACEHUB_API_TOKEN`.
+```sh
+python bin/embeddings_manager.py make <hf-model>/reactome/<Release#> --hf-key <your-key>
+```
+
+## Uploading to S3: `push`
+
+⚠️ Requires S3 write access.
+
+```sh
+python bin/embeddings_manager.py push openai/text-embedding-ada-002/reactome/Release89
+```

--- a/poetry.lock
+++ b/poetry.lock
@@ -380,6 +380,47 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "boto3"
+version = "1.34.148"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "boto3-1.34.148-py3-none-any.whl", hash = "sha256:d63d36e5a34533ba69188d56f96da132730d5e9932c4e11c02d79319cd1afcec"},
+    {file = "boto3-1.34.148.tar.gz", hash = "sha256:2058397f0a92c301e3116e9e65fbbc70ea49270c250882d65043d19b7c6e2d17"},
+]
+
+[package.dependencies]
+botocore = ">=1.34.148,<1.35.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.10.0,<0.11.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.34.148"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "botocore-1.34.148-py3-none-any.whl", hash = "sha256:9e09428b0bc4d0c1cf5e368dd6ab18eabf6047304060f8b5dd8391677cfe00e6"},
+    {file = "botocore-1.34.148.tar.gz", hash = "sha256:258dd95570b43db9fa21cce5426eabaea5867e3a61224157650448b5019d1bbd"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = [
+    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
+    {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
+]
+
+[package.extras]
+crt = ["awscrt (==0.20.11)"]
+
+[[package]]
 name = "build"
 version = "1.2.1"
 description = "A simple, correct Python build frontend"
@@ -1366,6 +1407,17 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
 
 [[package]]
 name = "joblib"
@@ -3515,6 +3567,23 @@ files = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.10.2"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "s3transfer-0.10.2-py3-none-any.whl", hash = "sha256:eca1c20de70a39daee580aef4986996620f365c4e0fda6a86100231d62f1bf69"},
+    {file = "s3transfer-0.10.2.tar.gz", hash = "sha256:0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6"},
+]
+
+[package.dependencies]
+botocore = ">=1.33.2,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
+
+[[package]]
 name = "safetensors"
 version = "0.4.3"
 description = ""
@@ -4413,6 +4482,22 @@ opentelemetry-sdk = ">=1.24,<2.0"
 
 [[package]]
 name = "urllib3"
+version = "1.26.19"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+files = [
+    {file = "urllib3-1.26.19-py2.py3-none-any.whl", hash = "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3"},
+    {file = "urllib3-1.26.19.tar.gz", hash = "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429"},
+]
+
+[package.extras]
+brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "urllib3"
 version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
@@ -4843,4 +4928,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <=3.12"
-content-hash = "a403629c8b5f4daf871f59c71f1249622c53bf8b6ffbfd8033792fea96441164"
+content-hash = "54a15ab933c7fdcdd764f3727add6b271fd38d3e4b8c5f73668aa863245f92d0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ langchain-community = "^0.2.5"
 langchain-core = "^0.2.7"
 langchain-huggingface = "^0.0.3"
 einops = "^0.8.0"
+boto3 = "^1.34.148"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.2.2"

--- a/src/reactome/retreival_chain.py
+++ b/src/reactome/retreival_chain.py
@@ -10,7 +10,7 @@ from langchain.retrievers.self_query.base import SelfQueryRetriever
 from langchain_community.chat_models import ChatOllama
 from langchain_community.vectorstores import Chroma
 from langchain_core.embeddings import Embeddings
-from langchain_huggingface import HuggingFaceEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings, HuggingFaceEndpointEmbeddings
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
 from src.reactome.metadata_info import descriptions_info, field_info
@@ -35,11 +35,17 @@ def get_embedding(
 ) -> Callable[[], Embeddings]:
     if hf_model is None:
         return OpenAIEmbeddings
-    return lambda: HuggingFaceEmbeddings(
-        model_name=hf_model,
-        model_kwargs={"device": device, "trust_remote_code": True},
-        encode_kwargs={"batch_size": 12, "normalize_embeddings": False},
-    )
+    elif "HUGGINGFACEHUB_API_TOKEN" in os.environ:
+        return lambda: HuggingFaceEndpointEmbeddings(
+            huggingfacehub_api_token=os.environ["HUGGINGFACEHUB_API_TOKEN"],
+            model=hf_model,
+        )
+    else:
+        return lambda: HuggingFaceEmbeddings(
+            model_name=hf_model,
+            model_kwargs={"device": device, "trust_remote_code": True},
+            encode_kwargs={"batch_size": 12, "normalize_embeddings": False},
+        )
 
 
 def initialize_retrieval_chain(

--- a/src/util/embedding_environment.py
+++ b/src/util/embedding_environment.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+EM_ARCHIVE = REPO_ROOT / "embeddings"
+EM_CURRENT = EM_ARCHIVE / "current"
+
+
+class EmbeddingEnvironment:
+    def __init__(self, env_path:str):
+        self.embeddings:dict[str, Path] = dict()
+        if env_path != "":
+            for embedding_path in map(Path, env_path.split(":")):
+                db = embedding_path.parent.name
+                self.embeddings[db] = embedding_path
+
+    @classmethod
+    def _get(cls): # -> Self
+        if EM_CURRENT.exists():
+            with EM_CURRENT.open("r") as current_fp:
+                env_path = current_fp.read()
+        else:
+            env_path = ""
+        return cls(env_path)
+
+    @classmethod
+    def get_dict(cls) -> dict[str, Path]:
+        return cls._get().embeddings
+
+    @classmethod
+    def set_one(cls, embedding_path:Path) -> None:
+        db = embedding_path.parent.name
+        embeddings_dict = cls.get_dict()
+        embeddings_dict[db] = embedding_path
+        env_path = ":".join(map(str, embeddings_dict.values()))
+        with EM_CURRENT.open("w") as current_fp:
+            current_fp.write(env_path)


### PR DESCRIPTION
Created `bin/embeddings_manager.py` as the main CLI for interacting with embeddings: generating embeddings, switching active embeddings, and downloading/uploading from S3.
See the new documentation (`docs/embeddings_manager.md`) in this PR for usage.

```
python .\bin\embeddings_manager.py -h
usage: embeddings_manager.py [-h] {pull,use,install,make,push,rm,ls,ls-remote,which} ...

positional arguments:
  {pull,use,install,make,push,rm,ls,ls-remote,which}
    pull                Download embeddings
    use                 Set the active embeddings
    install             Download and set the active embeddings (pull+use)
    make                Generate embeddings
    push                Upload embeddings
    rm                  Remove specified embedding (locally)
    ls                  List locally installed embeddings
    ls-remote           List available embeddings on S3
    which               Reveal the current embeddings in use
```

I've verified S3 functionality works with my configured AWS CLI credentials.

Also note that the `make` subcommand is intended to replace calling the individual embeddings generator scripts directly.

Please let me know if any clarifications/changes are needed.