### PR TITLE
parameterize OpenAI model

### DIFF
--- a/bin/chat-chainlit.py
+++ b/bin/chat-chainlit.py
@@ -30,6 +30,7 @@ llm_graph: RAGGraphWithMemory = create_retrieval_chain(
     ENV,
     EmbeddingEnvironment.get_dir(ENV),
     hf_model=EmbeddingEnvironment.get_model(ENV),
+    oai_model=os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 )
 
 if os.getenv("POSTGRES_CHAINLIT_DB"):

--- a/bin/chat-chainlit.py
+++ b/bin/chat-chainlit.py
@@ -30,7 +30,7 @@ llm_graph: RAGGraphWithMemory = create_retrieval_chain(
     ENV,
     EmbeddingEnvironment.get_dir(ENV),
     hf_model=EmbeddingEnvironment.get_model(ENV),
-    oai_model=os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    oai_model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
 )
 
 if os.getenv("POSTGRES_CHAINLIT_DB"):

--- a/src/retreival_chain.py
+++ b/src/retreival_chain.py
@@ -17,9 +17,8 @@ from langchain_core.retrievers import BaseRetriever
 from langchain_huggingface import (HuggingFaceEmbeddings,
                                    HuggingFaceEndpointEmbeddings)
 from langchain_ollama.chat_models import ChatOllama
-from langchain_openai.chat_models.base import BaseChatOpenAI, ChatOpenAI
+from langchain_openai.chat_models.base import ChatOpenAI
 from langchain_openai.embeddings import OpenAIEmbeddings
-from pydantic import SecretStr
 
 from conversational_chain.graph import RAGGraphWithMemory
 from reactome.metadata_info import descriptions_info, field_info

--- a/src/retreival_chain.py
+++ b/src/retreival_chain.py
@@ -70,7 +70,7 @@ def create_retrieval_chain(
         callbacks = [StreamingStdOutCallbackHandler()]
 
     llm: BaseChatModel
-    if ollama_model is None and oai_model:  # Use OpenAI when Ollama not specified
+    if ollama_model is None:  # Use OpenAI when Ollama not specified
         llm = ChatOpenAI(
             temperature=0.0,
             callbacks=callbacks,

--- a/src/retreival_chain.py
+++ b/src/retreival_chain.py
@@ -62,7 +62,7 @@ def create_retrieval_chain(
     ollama_model: Optional[str] = None,
     ollama_url: str = "http://localhost:11434",
     hf_model: Optional[str] = None,
-    oai_model: Optional[str] = "gpt-4o-mini",
+    oai_model: str = "gpt-4o-mini",
     device: str = "cpu",
 ) -> RAGGraphWithMemory:
     callbacks: list[BaseCallbackHandler] = []

--- a/src/retreival_chain.py
+++ b/src/retreival_chain.py
@@ -63,7 +63,7 @@ def create_retrieval_chain(
     ollama_model: Optional[str] = None,
     ollama_url: str = "http://localhost:11434",
     hf_model: Optional[str] = None,
-    ds_model: Optional[str] = None,
+    oai_model: Optional[str] = "gpt-4o-mini",
     device: str = "cpu",
 ) -> RAGGraphWithMemory:
     callbacks: list[BaseCallbackHandler] = []
@@ -71,21 +71,12 @@ def create_retrieval_chain(
         callbacks = [StreamingStdOutCallbackHandler()]
 
     llm: BaseChatModel
-    if ds_model and "DEEPSEEK_API_KEY" in os.environ:
-        llm = BaseChatOpenAI(
-            model=ds_model,
-            api_key=SecretStr(os.environ["DEEPSEEK_API_KEY"]),
-            base_url="https://api.deepseek.com",
-            temperature=0.0,
-            callbacks=callbacks,
-            verbose=verbose,
-        )
-    elif ollama_model is None:  # Use OpenAI when Ollama not specified
+    if ollama_model is None and oai_model:  # Use OpenAI when Ollama not specified
         llm = ChatOpenAI(
             temperature=0.0,
             callbacks=callbacks,
             verbose=verbose,
-            model="gpt-4o-mini",
+            model=oai_model,
         )
     else:  # Otherwise use Ollama
         llm = ChatOllama(


### PR DESCRIPTION
Slight change to allow for configurable LLM model for OpenAI queries via the `OPENAI_MODEL` environment variable.
If not provided, default to `gpt-4o-mini` as was previously hardcoded.
Everything should behave exactly the same with this change until the environment variable is set to a different model.