### PR TITLE
reduce default chunksize for reactome embedding generation

### DIFF
--- a/src/data_generation/reactome/__init__.py
+++ b/src/data_generation/reactome/__init__.py
@@ -53,11 +53,13 @@ def upload_to_chromadb(
     embeddings_instance: Embeddings
     if hf_model is None:  # Use OpenAI
         embeddings_instance = OpenAIEmbeddings(
+            chunk_size=500,
             show_progress_bar=True,
         )
     elif hf_model.startswith("openai/text-embedding-"):
         embeddings_instance = OpenAIEmbeddings(
             model=hf_model[len("openai/") :],
+            chunk_size=500,
             show_progress_bar=True,
         )
     elif "HUGGINGFACEHUB_API_TOKEN" in os.environ:


### PR DESCRIPTION
Default `OpenAIEmbeddings` request chunk size is 1000.
This started exceeding the token limit for recent Reactome releases.
Changed to 500, no longer exceeds API token limit.