### PR TITLE
feat: make LLM and embedding model configurable via YAML config

### DIFF
--- a/bin/chat-chainlit.py
+++ b/bin/chat-chainlit.py
@@ -20,7 +20,8 @@ load_dotenv()
 config: Config | None = Config.from_yaml()
 
 profiles: list[ProfileName] = config.profiles if config else [ProfileName.React_to_Me]
-llm_graph = AgentGraph(profiles)
+models_config = config.models if config else None
+llm_graph = AgentGraph(profiles, models_config=models_config)
 
 POSTGRES_CHAINLIT_DB = os.getenv("POSTGRES_CHAINLIT_DB")
 POSTGRES_USER = os.getenv("POSTGRES_USER")

--- a/config_default.yml
+++ b/config_default.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=./.config.schema.yaml
 
+models:
+  llm:
+    provider: openai
+    model: gpt-4o-mini
+  embedding:
+    provider: openai
+    model: text-embedding-3-large
+
 profiles:
   - React-to-Me
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -16,6 +16,7 @@ from psycopg_pool import AsyncConnectionPool
 from agent.models import get_embedding, get_llm
 from agent.profiles import ProfileName, create_profile_graphs
 from agent.profiles.base import InputState, OutputState
+from util.config_yml.models import EmbeddingConfig, LLMConfig, ModelsConfig
 from util.logging import logging
 
 LANGGRAPH_DB_URI = f"postgresql://{os.getenv('POSTGRES_USER')}:{os.getenv('POSTGRES_PASSWORD')}@postgres:5432/{os.getenv('POSTGRES_LANGGRAPH_DB')}?sslmode=disable"
@@ -28,10 +29,21 @@ class AgentGraph:
     def __init__(
         self,
         profiles: list[ProfileName],
+        models_config: ModelsConfig | None = None,
     ) -> None:
-        # Get base models
-        llm: BaseChatModel = get_llm("openai", "gpt-4o-mini")
-        embedding: Embeddings = get_embedding("openai", "text-embedding-3-large")
+        # Get base models from config (with backward-compatible defaults)
+        if models_config is None:
+            models_config = ModelsConfig()
+
+        llm_cfg: LLMConfig = models_config.llm
+        emb_cfg: EmbeddingConfig = models_config.embedding
+
+        llm: BaseChatModel = get_llm(
+            llm_cfg.provider, llm_cfg.model, base_url=llm_cfg.base_url
+        )
+        embedding: Embeddings = get_embedding(
+            emb_cfg.provider, emb_cfg.model, device=emb_cfg.device
+        )
 
         self.uncompiled_graph: dict[str, StateGraph] = create_profile_graphs(
             profiles, llm, embedding

--- a/src/util/config_yml/__init__.py
+++ b/src/util/config_yml/__init__.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Self
 
 import yaml
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from agent.profiles import ProfileName
 from util.config_yml.features import Feature, Features
@@ -17,6 +17,8 @@ CONFIG_DEFAULT_YML = Path("config_default.yml")
 
 
 class Config(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
     features: Features
     messages: dict[str, Message]
     models: ModelsConfig = ModelsConfig()

--- a/src/util/config_yml/__init__.py
+++ b/src/util/config_yml/__init__.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ValidationError
 from agent.profiles import ProfileName
 from util.config_yml.features import Feature, Features
 from util.config_yml.messages import Message, TriggerEvent
+from util.config_yml.models import EmbeddingConfig, LLMConfig, ModelsConfig
 from util.config_yml.usage_limits import MessageRate, UsageLimits
 from util.config_yml.user_matching import match_user
 from util.logging import logging
@@ -18,6 +19,7 @@ CONFIG_DEFAULT_YML = Path("config_default.yml")
 class Config(BaseModel):
     features: Features
     messages: dict[str, Message]
+    models: ModelsConfig = ModelsConfig()
     profiles: list[ProfileName]
     usage_limits: UsageLimits
 

--- a/src/util/config_yml/models.py
+++ b/src/util/config_yml/models.py
@@ -1,0 +1,20 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class LLMConfig(BaseModel):
+    provider: Literal["openai", "ollama"] | str = "openai"
+    model: str = "gpt-4o-mini"
+    base_url: str | None = None
+
+
+class EmbeddingConfig(BaseModel):
+    provider: Literal["openai", "huggingfacehub", "huggingfacelocal"] | str = "openai"
+    model: str = "text-embedding-3-large"
+    device: str | None = "cpu"
+
+
+class ModelsConfig(BaseModel):
+    llm: LLMConfig = LLMConfig()
+    embedding: EmbeddingConfig = EmbeddingConfig()


### PR DESCRIPTION
## Summary

Make LLM and embedding model/provider configurable via the existing YAML config system instead of being hard-coded in `AgentGraph.__init__()`.

## Problem

The model provider and model name were hard-coded in `AgentGraph.__init__()`:

```python
llm: BaseChatModel = get_llm("openai", "gpt-4o-mini")
embedding: Embeddings = get_embedding("openai", "text-embedding-3-large")
```

This made it impossible to switch models, providers, or base URLs without directly modifying source code — limiting experimentation, self-hosting with local models (e.g., Ollama), and deployment flexibility.

## Solution

Introduce a `ModelsConfig` Pydantic model and wire it through the existing YAML config pipeline so users can control models declaratively:

```yaml
# config.yml / config_default.yml
models:
  llm:
    provider: openai        # or "ollama"
    model: gpt-4o-mini      # any model supported by the provider
    # base_url: http://localhost:11434  # optional, for self-hosted endpoints
  embedding:
    provider: openai         # or "huggingfacehub", "huggingfacelocal"
    model: text-embedding-3-large
    # device: cpu            # optional, for local HuggingFace models
```

`AgentGraph` now reads from config instead of hard-coded values:

```python
llm: BaseChatModel = get_llm(
    llm_cfg.provider, llm_cfg.model, base_url=llm_cfg.base_url
)
embedding: Embeddings = get_embedding(
    emb_cfg.provider, emb_cfg.model, device=emb_cfg.device
)
```

## Changes

| File | Change |
|------|--------|
| `src/util/config_yml/models.py` | **New** — `LLMConfig`, `EmbeddingConfig`, and `ModelsConfig` Pydantic models with sensible defaults |
| `src/util/config_yml/__init__.py` | Added `models: ModelsConfig` field to `Config` with a default so existing configs without the key still work |
| `src/agent/graph.py` | `AgentGraph.__init__()` accepts optional `ModelsConfig`; reads provider/model from config instead of hard-coded strings |
| `bin/chat-chainlit.py` | Passes `config.models` through to `AgentGraph` at startup |
| `config_default.yml` | Added `models` section with current default values documented |

## Backward Compatibility

- The `models` key in YAML is **optional** — `ModelsConfig` defaults to `openai/gpt-4o-mini` and `openai/text-embedding-3-large`, matching the previously hard-coded values.
- `AgentGraph` accepts `models_config=None` and falls back to the same defaults.
- Existing `config.yml` files without a `models` section continue to work without modification.

## Example: Switching to Ollama

```yaml
models:
  llm:
    provider: ollama
    model: llama3
    base_url: http://localhost:11434
  embedding:
    provider: huggingfacelocal
    model: BAAI/bge-small-en-v1.5
    device: cuda
```

No code changes required — just update the YAML config and restart.

## How This Enables Future MCP Integration

- **Decouples model selection from orchestration logic** — the `AgentGraph` no longer owns provider/model decisions, making it easier for an MCP server to initialize its own LLM instances from the same shared config.
- **Establishes a config-driven pattern** — the new `ModelsConfig` Pydantic model provides a validated, extensible schema. Future MCP settings (server URL, transport, tool registrations) can follow the same pattern and live alongside it in `config.yml`.
- **Reduces hard-coded coupling identified as a blocker** — the architecture analysis explicitly listed hard-coded model selection as a limitation for MCP integration. This PR removes that limitation.
- **Supports diverse deployment topologies** — MCP servers may run with different model backends (e.g., a local Ollama instance for development, OpenAI for production). Config-driven model selection makes this seamless without code forks.

## Related Issue

Resolves #108
