### PR TITLE
fix: remove hard-coded absolute paths from evaluator

### DIFF
--- a/src/evaluation/evaluator.py
+++ b/src/evaluation/evaluator.py
@@ -18,6 +18,7 @@ from retrievers.rag_chain import create_rag_chain
 from retrievers.reactome.metadata_info import (reactome_descriptions_info,
                                                reactome_field_info)
 from retrievers.reactome.prompt import reactome_qa_prompt
+from util.embedding_environment import EmbeddingEnvironment
 
 context_utilization = ContextUtilization()
 
@@ -45,6 +46,20 @@ def parse_arguments():
         required=True,
         help="Type of RAG system to use for evaluation",
     )
+    parser.add_argument(
+        "--embeddings_dir",
+        type=str,
+        default=None,
+        help="Path to the ChromaDB embeddings directory (e.g., .../summations). "
+        "Defaults to the active Reactome embedding resolved via embeddings/current.",
+    )
+    parser.add_argument(
+        "--csv_path",
+        type=str,
+        default=None,
+        help="Path to the summations CSV file for BM25 retrieval. "
+        "Defaults to the csv_files/summations.csv sibling of --embeddings_dir.",
+    )
     return parser.parse_args()
 
 
@@ -61,14 +76,14 @@ def load_dataset(testset_path):
         raise ValueError(f"Error reading the Excel file: {e}")
 
 
-def initialize_rag_chain_with_memory(embeddings_directory, model_name, rag_type):
+def initialize_rag_chain_with_memory(
+    embeddings_directory, csv_path, model_name, rag_type
+):
     """Initialize the RAGChainWithMemory system."""
     llm = ChatOpenAI(temperature=0.0, verbose=True, model=model_name)
     retriever_list = []
 
-    loader = CSVLoader(
-        "/Users/hmohammadi/Desktop/react_to_me_github/reactome_chatbot/embeddings/openai/text-embedding-3-large/reactome/summation_csv/summations.csv"
-    )
+    loader = CSVLoader(csv_path)
     data = loader.load()
     bm25_retriever = BM25Retriever.from_documents(data)
     bm25_retriever.k = 7
@@ -167,6 +182,33 @@ def process_testset(
     print(f"Evaluation results saved to {evaluation_filename}")
 
 
+def _resolve_paths(args):
+    """Resolve embeddings directory and CSV path from CLI args or EmbeddingEnvironment."""
+    embeddings_dir = args.embeddings_dir
+    csv_path = args.csv_path
+
+    if embeddings_dir is None:
+        reactome_dir = EmbeddingEnvironment.get_dir("reactome")
+        if reactome_dir is None:
+            raise FileNotFoundError(
+                "No active Reactome embedding found. Either run "
+                "'embeddings_manager use' to set one, or pass --embeddings_dir explicitly."
+            )
+        embeddings_dir = str(reactome_dir / "summations")
+
+    if csv_path is None:
+        # Convention: CSV files live in a csv_files/ sibling directory
+        parent = os.path.dirname(embeddings_dir)
+        csv_path = os.path.join(parent, "csv_files", "summations.csv")
+
+    if not os.path.isdir(embeddings_dir):
+        raise FileNotFoundError(f"Embeddings directory not found: {embeddings_dir}")
+    if not os.path.isfile(csv_path):
+        raise FileNotFoundError(f"CSV file not found: {csv_path}")
+
+    return embeddings_dir, csv_path
+
+
 def main():
     args = parse_arguments()
     model_name = args.model
@@ -176,10 +218,12 @@ def main():
     os.makedirs(response_dir, exist_ok=True)
     os.makedirs(eval_dir, exist_ok=True)
 
+    # Resolve embeddings and CSV paths
+    embeddings_directory, csv_path = _resolve_paths(args)
+
     # Initialize RAG Chain
-    embeddings_directory = "/Users/hmohammadi/Desktop/react_to_me_github/reactome_chatbot/embeddings/openai/text-embedding-3-large/reactome/Release90/summations"
     qa_system = initialize_rag_chain_with_memory(
-        embeddings_directory, model_name, rag_type
+        embeddings_directory, csv_path, model_name, rag_type
     )
 
     # Iterate over all .xlsx files in the directory


### PR DESCRIPTION
## Summary

Remove hard-coded absolute paths from the evaluation script and make them configurable via CLI arguments, with automatic fallback to the project's existing `EmbeddingEnvironment` resolver.

## Problem

`src/evaluation/evaluator.py` contained two hard-coded absolute paths pointing to a specific developer's local machine:

```python
# Line 74 — CSV path for BM25 retrieval
loader = CSVLoader(
    "/Users/hmohammadi/Desktop/react_to_me_github/reactome_chatbot/embeddings/.../summations.csv"
)

# Line 182 — ChromaDB embeddings directory
embeddings_directory = "/Users/hmohammadi/Desktop/react_to_me_github/reactome_chatbot/embeddings/.../summations"
```

This made it impossible to:
- Run the evaluator on any other machine
- Use it in CI/CD pipelines
- Containerize the evaluation workflow with Docker

## Solution

Replace the hard-coded paths with two new CLI arguments that integrate with the project's existing `EmbeddingEnvironment` utility:

```sh
# Zero-config: auto-resolves from embeddings/current
python evaluator.py --testset_dir ./example --rag_type advanced

# Explicit override when needed
python evaluator.py --testset_dir ./example --rag_type advanced \
  --embeddings_dir ./embeddings/openai/text-embedding-3-large/reactome/Release90/summations \
  --csv_path ./embeddings/openai/text-embedding-3-large/reactome/csv_files/summations.csv
```

### Path Resolution Logic

```
--embeddings_dir provided?
  ├── Yes → use it directly
  └── No  → EmbeddingEnvironment.get_dir("reactome") / "summations"

--csv_path provided?
  ├── Yes → use it directly
  └── No  → <parent of embeddings_dir> / "csv_files" / "summations.csv"

Both paths validated for existence before proceeding.
```

## Changes

| File | Change |
|------|--------|
| `src/evaluation/evaluator.py` | Removed 2 hard-coded absolute paths; added `--embeddings_dir` and `--csv_path` CLI args; added `_resolve_paths()` helper with `EmbeddingEnvironment` fallback and existence validation; updated `initialize_rag_chain_with_memory()` signature to accept `csv_path` |

## Design Decisions

- **CLI arguments over environment variables** — consistent with the script's existing `argparse` interface (`--testset_dir`, `--model`, `--rag_type`) and the companion `test_generator.py` which also uses `argparse`.
- **Fallback to `EmbeddingEnvironment`** — reuses the project's existing path resolution utility (`src/util/embedding_environment.py`) rather than inventing a new mechanism. This is the same resolver used by the main application at runtime.
- **Both args optional** — enables zero-config usage for developers who have already run `embeddings_manager use`, while CI and Docker can pass explicit paths.
- **Existence validation** — `_resolve_paths()` raises `FileNotFoundError` with a clear message before any expensive initialization runs.

## Backward Compatibility

- All existing CLI arguments remain unchanged.
- The script runs identically to before when explicit `--embeddings_dir` and `--csv_path` are provided matching the old hard-coded values.
- No changes to any other files in the repository.

## Related Issue

Resolves #109
