### PR TITLE
fix: replace mutable default arguments in Config methods

### DIFF
--- a/src/util/config_yml/__init__.py
+++ b/src/util/config_yml/__init__.py
@@ -37,8 +37,10 @@ class Config(BaseModel):
         user_id: str | None = None,
         event: TriggerEvent | None = None,
         after_messages: int | None = None,
-        last_messages: dict[str, str] = {},
+        last_messages: dict[str, str] | None = None,
     ) -> dict[str, str]:
+        if last_messages is None:
+            last_messages = {}
         return {
             message_id: message.message
             for message_id, message in self.messages.items()
@@ -54,8 +56,10 @@ class Config(BaseModel):
     def get_message_rate_usage_limited(
         self,
         user_id: str | None = None,
-        message_times_queue: list[str] = [],
+        message_times_queue: list[str] | None = None,
     ) -> MessageRate | None:
+        if message_times_queue is None:
+            message_times_queue = []
         message_rate: MessageRate
         for message_rate in self.usage_limits.message_rates:
             if match_user(message_rate.users, user_id):


### PR DESCRIPTION
## Summary

Replace mutable default arguments (`{}` and `[]`) with `None` in two `Config` methods to prevent potential shared-state issues across calls.

In Python, default argument values are evaluated once at function definition time, meaning mutable defaults can be shared between calls if mutated.
Reference: [https://docs.python.org/3/faq/programming.html#why-are-default-values-shared-between-objects](https://docs.python.org/3/faq/programming.html#why-are-default-values-shared-between-objects)

---

## Problem

Two methods in `src/util/config_yml/__init__.py` use mutable default arguments:

```python
# Line ~40
def get_messages(self, ..., last_messages: dict[str, str] = {})

# Line ~57
def get_message_rate_usage_limited(self, ..., message_times_queue: list[str] = [])
```

If these objects are ever mutated in-place (e.g., `dict[key] = value` or `list.append()`), the mutation persists across subsequent calls, which may lead to unintended shared state.

This pattern is commonly flagged by Python linters:

* `pylint` → `W0102`
* `flake8-bugbear` → `B006`
* `ruff` → `B006`

---

## Solution

Use `None` as the default value and instantiate a fresh object inside the function body.

```diff
def get_messages(
    self,
    user_id: str | None = None,
    event: TriggerEvent | None = None,
    after_messages: int | None = None,
-   last_messages: dict[str, str] = {},
+   last_messages: dict[str, str] | None = None,
) -> dict[str, str]:

+   if last_messages is None:
+       last_messages = {}
```

```diff
def get_message_rate_usage_limited(
    self,
    user_id: str | None = None,
-   message_times_queue: list[str] = [],
+   message_times_queue: list[str] | None = None,
) -> MessageRate | None:

+   if message_times_queue is None:
+       message_times_queue = []
```

---

## Impact

* No behavioral change for current callers.
* Prevents potential shared mutable state if the default arguments are used in future code paths.
* Aligns with common Python best practices and linter recommendations.

---

## Files Changed

* `src/util/config_yml/__init__.py`


Fixes #130 

