### PR TITLE
feat(retriever): add token-aware context truncation to cap documents passed to LLM

### DIFF
--- a/config_default.yml
+++ b/config_default.yml
@@ -3,6 +3,11 @@
 profiles:
   - React-to-Me
 
+retriever:
+  context_truncation:
+    max_docs: 15
+    max_tokens: 12000
+
 features:
   postprocessing:  # external web search feature
     enabled: true

--- a/src/retrievers/csv_chroma.py
+++ b/src/retrievers/csv_chroma.py
@@ -17,6 +17,7 @@ from langchain_core.prompts.prompt import PromptTemplate
 from nltk.tokenize import word_tokenize
 from pydantic import AfterValidator, Field
 from pydantic.json_schema import SkipJsonSchema
+from util.context_truncator import truncate_to_token_limit
 
 chroma_settings = chromadb.config.Settings(anonymized_telemetry=False)
 
@@ -179,7 +180,7 @@ class HybridRetriever(MultiQueryRetriever):
                 )
                 doc_lists.append(bm25_docs + vector_docs)
             subdirectory_docs.extend(self.weighted_reciprocal_rank(doc_lists))
-        return subdirectory_docs
+        return truncate_to_token_limit(subdirectory_docs)
 
     async def aretrieve_documents(
         self, queries: list[str], run_manager
@@ -219,4 +220,4 @@ class HybridRetriever(MultiQueryRetriever):
                 for bm25_results, vector_results in zip(results_iter, results_iter)
             ]
             subdirectory_docs.extend(self.weighted_reciprocal_rank(doc_lists))
-        return subdirectory_docs
+        return truncate_to_token_limit(subdirectory_docs)

--- a/src/util/context_truncator.py
+++ b/src/util/context_truncator.py
@@ -1,0 +1,32 @@
+from langchain_core.documents import Document
+import tiktoken
+
+
+def truncate_to_token_limit(
+    docs: list[Document],
+    max_docs: int = 15,
+    max_tokens: int = 12000,
+    model: str = "gpt-4o",
+) -> list[Document]:
+    """
+    Truncate document list to fit within token and count budgets.
+    Docs must already be ranked from best to worst (e.g. WRR).
+    Cuts from the bottom so least relevant docs are removed first.
+    """
+    encoder = tiktoken.encoding_for_model(model)
+    result = []
+    total_tokens = 0
+
+    for doc in docs[:max_docs]:
+        doc_tokens = len(encoder.encode(doc.page_content))
+
+        if total_tokens + doc_tokens > max_tokens:
+            # always include at least one doc even if it exceeds budget
+            if not result:
+                result.append(doc)
+            break
+
+        result.append(doc)
+        total_tokens += doc_tokens
+
+    return result


### PR DESCRIPTION
## Summary

Adds token-aware context truncation to `HybridRetriever` to cap the number of documents and tokens passed to the LLM. Fixes the unbounded document passing problem described in #138.

## Motivation

`create_stuff_documents_chain` in `rag_chain.py` stuffs ALL retrieved documents into the LLM context with zero token awareness. With two databases installed (Reactome + UniProt), this results in 60-100 documents per query reaching the LLM, causing:

- Verbose, unfocused answers from too much noisy context
- High token cost depending on the number of tokens in a document and the current OpenAI API cost.
- "Lost in the middle" degradation - LLMs ignore middle documents in long contexts.

## Changes

### New - `src/util/context_truncator.py`
- `truncate_to_token_limit()` - truncates a ranked document list to fit within a token budget and document count limit
- Uses tiktoken for exact GPT-4o token counting - already installed via `langchain-openai`, zero new dependencies
- Processes documents in order (best first) and stops when either limit is hit - least relevant documents always removed first
- Guarantees at least one document is always returned even if it exceeds the token budget, preventing empty context edge case

### Modified - `src/retrievers/csv_chroma.py`
- `retrieve_documents()` - returns `truncate_to_token_limit(subdirectory_docs)` instead of raw `subdirectory_docs`
- `aretrieve_documents()` - same change applied to async retrieval path
- Added import for `truncate_to_token_limit` from `util.context_truncator`

### Modified - `config_default.yml`
- Added `retriever.context_truncation` block with `max_docs: 15` and `max_tokens: 12000`
- Config wiring to `HybridRetriever` can be added later - current defaults are hardcoded

## Why These Default Values
```
max_docs: 15
  15 high quality ranked docs provides sufficient context for any question
  beyond this quality degrades due to lost-in-the-middle effect

max_tokens: 12000
  leaves room for system prompt + chat history + answer
  within GPT-4o's 128k context window
```
## Expected Impact

Limits context passed to the LLM to a maximum of 15 documents and 12,000 tokens per query, down from an unbounded 60-100 documents. This reduces token usage significantly and avoids the "lost in the middle" quality degradation that occurs with excessively long contexts.

Note: Exact token counts per document depend on installed database versions and chunk sizes. A follow-up evaluation with real embeddings will quantify the precise reduction.

Note: GPT-4o supports a 128k context window but the 12,000 token limit  is intentional - it reserves space for system prompt, chat history, and  model output, while avoiding the "lost in the middle" quality degradation that occurs with excessively long contexts.

## Interaction With Other PRs

Truncation runs at the end of `retrieve_documents()` and `aretrieve_documents()` - after WRR ranking and after FlashRank reranking (PR #116). This means truncation always removes the least relevant documents from last, preserving quality ordering established by both ranking stages.
```
BM25 + Vector retrieval
      ->
weighted_reciprocal_rank
      ->
FlashRank reranking (PR #116)
      ->
truncate_to_token_limit()   
      ->
create_stuff_documents_chain
```

## Related
- Closes #138 
- Complements PR #116 (FlashRank reranking)
- Complements PR #121 (prompt precision)