### PR TITLE
fix: make AgentGraph destructor loop-safe to prevent connection leaks

### DIFF
--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -43,7 +43,15 @@ class AgentGraph:
 
     def __del__(self) -> None:
         if self.pool:
-            asyncio.run(self.close_pool())
+            try:
+                loop = asyncio.get_running_loop()
+                if loop.is_running():
+                    loop.create_task(self.close_pool())
+                else:
+                    asyncio.run(self.close_pool())
+            except RuntimeError:
+                # No event loop is running
+                asyncio.run(self.close_pool())
 
     async def initialize(self) -> dict[str, CompiledStateGraph]:
         checkpointer: BaseCheckpointSaver[str] = await self.create_checkpointer()


### PR DESCRIPTION
## Problem

The `AgentGraph` destructor (`__del__`) currently calls `asyncio.run(self.close_pool())`. In an asynchronous environment (like a Chainlit or FastAPI server), if the agent instance is deleted while an event loop is already running, `asyncio.run()` raises a `RuntimeError: This event loop is already running`. Because the destructor fails mid-execution, the connection pool is never closed, leading to hanging database connections and potential pool exhaustion.

## Fix #146 

Updated the destructor to be loop-aware. It now checks for a running event loop and schedules the cleanup task using `loop.create_task()` instead of attempting to start a new nested loop.

> [!IMPORTANT]
> `loop.create_task()` during `__del__` is best-effort. If the event
> loop closes before the task executes, cleanup may still be skipped.
> The robust long-term solution is explicit lifecycle management via a
> `shutdown()` method, but this fix resolves the immediate
> `RuntimeError` and improves reliability during server reloads.

## Verification

Verified with a standalone validation script covering two scenarios:

1. **Active Loop:** Confirmed that `close_pool` is scheduled as a task when a loop is running.
2. **No Loop:** Confirmed that `asyncio.run` is used as a fallback when no loop is present (e.g., script exit).

## Files Affected

- `src/agent/graph.py`